### PR TITLE
ssh-stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Watchdog
 
 Herd
 - add forced reboot via sysrq (CLI `unstick`). SYSRQD_KEY must be present in env-variables
+- make .open() less demanding
 
 Ansible
 - cleaning-role
@@ -17,8 +18,9 @@ Ansible
 - maintenance-role - integrate harden_fs
 - observer-role
   - allow adding datastorage without connection
-  - grow root-partition/FS
+  - grow root-partition/FS (disabled for now)
 - general speedup by using new config-options (fact caching, skipping compression, keeping ssh-connections)
+- improve sshd-stability
 - ptp-host-role
   - revert to use included PTP
   - try normal hw-filtering
@@ -27,6 +29,7 @@ Ansible
 Misc
 - add custom compiled PTP
 - update cape-errata, h5-benchmark
+- sheep - fix exception during end of resync
 
 ## 2026.07.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,14 @@ Ansible
   - speed up package-removal
 - harden_fs - remove new swap, improve root-detection
 - maintenance-role - integrate harden_fs
-- observer-role - allow adding datastorage without connection
+- observer-role
+  - allow adding datastorage without connection
+  - grow root-partition/FS
 - general speedup by using new config-options (fact caching, skipping compression, keeping ssh-connections)
+- ptp-host-role
+  - revert to use included PTP
+  - try normal hw-filtering
+  - disable PTP-compiling and reload systemd after setup
 
 Misc
 - add custom compiled PTP

--- a/deploy/bootstrap.yml
+++ b/deploy/bootstrap.yml
@@ -1,6 +1,8 @@
 ---
 # sets up passwordless access for new user
-
+# TODO: this script should:
+#       - handle access / accounts
+#       - hostname & mac-address to IP config
 - name: Base setup
   hosts: all
   become: true

--- a/deploy/dev_acquire_image.yml
+++ b/deploy/dev_acquire_image.yml
@@ -2,7 +2,7 @@
 # cleans up sheep0 to allow pulling an image
 
 - name: Delete space wasting or forgotten files (WARNING - includes recordings) and cleans up free space to prepare image-extraction
-  hosts: sheep0
+  hosts: sheep
   become: true
   gather_facts: true
 

--- a/deploy/roles/cleaning/tasks/software.yml
+++ b/deploy/roles/cleaning/tasks/software.yml
@@ -24,13 +24,14 @@
 - name: APT - Uninstall non-essential Packages
   # ansible.builtin.apt: -> replaced because it's much slower
   # NOTE: handing the whole list at once would be faster, but trades off control
-  ansible.builtin.command: 'apt purge -y {{ item }}'
+  ansible.builtin.command: 'apt purge --yes {{ item }}'
   failed_when: false
+  changed_when:
   with_items: "{{ cleaning_packages }}"
   become: true
 
 - name: APT - remove orphaned dependencies
-  ansible.builtin.command: 'apt autoremove -y'
+  ansible.builtin.command: 'apt autoremove --yes'
   become: true
 
 - name: Remove extra Firmwares

--- a/deploy/roles/maintenance/tasks/performance.yml
+++ b/deploy/roles/maintenance/tasks/performance.yml
@@ -3,23 +3,26 @@
 - name: CFG - Improve SSH-Speed
   ansible.builtin.lineinfile:
     dest: /etc/ssh/sshd_config
+    # TODO: better use /etc/ssh/sshd_config.d/*.conf
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     state: present
   loop:
-    - {regex: '^.*UseDNS.*$', line: 'UseDNS no'}  # additional check with added latency
-    - {regex: '^.*Compression.*$', line: 'Compression no'}  # additional CPU-load
+    - {regex: '^.*UseDNS.*$', line: 'UseDNS no'}  # additional check with added latency, default=no
+    - {regex: '^.*Compression.*$', line: 'Compression no'}  # additional CPU-load, default=yes
 
 - name: CFG - Improve SSH-Stability
   ansible.builtin.lineinfile:
     dest: /etc/ssh/sshd_config
+    # TODO: better use /etc/ssh/sshd_config.d/*.conf
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     state: present
   loop:
-    - {regex: '^.*ClientAliveInterval .*$', line: 'ClientAliveInterval  60'}
-    - {regex: '^.*ClientAliveCountMax.*$', line: 'ClientAliveCountMax 10'}
-    - {regex: '^.*TCPKeepAlive.*$', line: 'TCPKeepAlive yes'}
+    - {regex: '^.*ClientAliveInterval .*$', line: 'ClientAliveInterval  10'} # default=0/off
+    - {regex: '^.*ClientAliveCountMax.*$', line: 'ClientAliveCountMax 10'} # default=3
+      # interval * countMax = TTL before disconnect
+    - {regex: '^.*TCPKeepAlive.*$', line: 'TCPKeepAlive yes'} # default=yes
 
 - name: CFG - Adapt default Target to multi-user
   ansible.builtin.command: 'systemctl set-default multi-user'

--- a/deploy/roles/ptp_host/files/phc2sys@.service
+++ b/deploy/roles/ptp_host/files/phc2sys@.service
@@ -11,8 +11,8 @@ Type=idle
 ExecStartPre=-/bin/sleep 5
 # ExecStart=/usr/sbin/phc2sys -w -s %I
 # ExecStart=/usr/sbin/phc2sys -rr -w -s %I
-# ExecStart=/usr/sbin/phc2sys -r -w -s %I -E linreg
-ExecStart=/usr/local/sbin/phc2sys -r -w -s %I -E linreg
+ExecStart=/usr/sbin/phc2sys -r -w -s %I -E linreg
+# ExecStart=/usr/local/sbin/phc2sys -r -w -s %I -E linreg
 # for client: -r -w -s %I -E linreg
 # for server: -a -rr -E linreg, TODO: put in ansible
 # for both:   -rr -w -s %I -E linreg

--- a/deploy/roles/ptp_host/files/ptp4l@.service
+++ b/deploy/roles/ptp_host/files/ptp4l@.service
@@ -9,8 +9,8 @@ Type=idle
 ExecStartPre=/usr/sbin/ntpdate -b -s -u pool.ntp.org
 ExecStartPre=-/usr/local/bin/set-ptp-kworker-prio.sh
 # ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/ptp4l.conf -i %I
-# ExecStart=/usr/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
-ExecStart=/usr/local/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
+ExecStart=/usr/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
+# ExecStart=/usr/local/sbin/ptp4l -A -H -f /etc/linuxptp/ptp4l.conf -i %I
 # -2 -> IEEE 802.3 Network Transport, TODO: seems to produce "sheep03 ptp4l[4062]: [2837.436] port 1: bad message"
 # -A -> Auto Delay Mechanism (E2E first, then maybe P2P)
 # -H -> use hardware timestamping

--- a/deploy/roles/ptp_host/tasks/main.yml
+++ b/deploy/roles/ptp_host/tasks/main.yml
@@ -104,7 +104,8 @@
     }
     - {
       regex: "^.?hwts_filter.*$",
-      replacement: "# hwts_filter  check", # normal is default
+      replacement: "hwts_filter  normal", # normal is default
+      # - None, when line not present
       # - Normal mode set the filters as needed.
       # - Check mode only check but do not set.
       # - Full mode set the receive filter to mark all packets with hardware time stamp,

--- a/deploy/roles/ptp_host/tasks/main.yml
+++ b/deploy/roles/ptp_host/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Compile newest LinuxPTP
   ansible.builtin.include_tasks:
     file: compile_ptp.yml
+  when: false
 
 - name: Configure PTP - Hardware-timestamping
   ansible.builtin.lineinfile:
@@ -138,6 +139,9 @@
   # Tests
   # manual: sudo systemctl restart ptp4l@eth0
   # status: sudo journalctl -u ptp4l@eth0 -f
+
+- name: Reload source-configuration-files
+  ansible.builtin.command: 'systemctl daemon-reload'
 
 - name: Deploy prio-script for kworker
   ansible.builtin.copy:

--- a/deploy/roles/secure_testbed/tasks/main.yml
+++ b/deploy/roles/secure_testbed/tasks/main.yml
@@ -19,14 +19,21 @@
 - name: CFG - Improve SSHd-Security
   ansible.builtin.lineinfile:
     dest: /etc/ssh/sshd_config
+    # TODO: better use /etc/ssh/sshd_config.d/*.conf
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
     state: present
   loop:
     - {regex: '^.*Protocol.*$', line: 'Protocol 2'}
-    - {regex: '^.*StrictModes.*$', line: 'StrictModes yes'}
-    - {regex: '^.*LoginGraceTime.*$', line: 'LoginGraceTime 1m'}
-#    - {regex: '^.*MaxAuthTries.*$', line: 'MaxAuthTries 3'}
+    - {regex: '^.*StrictModes.*$', line: 'StrictModes yes'} # default=yes
+    - {regex: '^.*LoginGraceTime.*$', line: 'LoginGraceTime 10'} # default=120
+          # TODO: was 60, test 10
+    - {regex: '^.*MaxAuthTries.*$', line: 'MaxAuthTries 20'} # default=6
+          # -> higher value increases risk of DDoS, but Server tries reconnecting a lot
+          # TODO: was default, try more to avoid blocking of server
+    - {regex: '^.*UnusedConnectionTimeout.*$', line: 'UnusedConnectionTimeout 30'} # default=none
+          # TODO: possible addition: "ChannelTimeout session=5m"-parameter
+          # TODO: better suited in performance/stability category
     - {regex: '^.*PermitRootLogin.*$', line: 'PermitRootLogin no'}
     - {regex: '^.*PasswordAuthentication.*$', line: 'PasswordAuthentication no'} # disable for debug
     - {regex: '^.*PermitEmptyPasswords.*$', line: 'PermitEmptyPasswords no'}

--- a/deploy/roles/testbed_observer/tasks/grow_root_partition.yml
+++ b/deploy/roles/testbed_observer/tasks/grow_root_partition.yml
@@ -12,3 +12,4 @@
     cmd: 'sudo resize2fs /dev/mmcblk0p1'
 
 # df -hT | grep -e 'mmcblk.*ext4.* /' | cut -d" " -s --fields=3
+# df -T | grep -e 'mmcblk.*ext4.* /' | tr -s [:space:] | cut -d' ' -s --fields=3

--- a/deploy/roles/testbed_observer/tasks/grow_root_partition.yml
+++ b/deploy/roles/testbed_observer/tasks/grow_root_partition.yml
@@ -1,0 +1,14 @@
+# Steps
+# - get initial size
+# - grow partition and FS
+# - compare size-grow
+
+- name: Resize Partition
+  ansible.builtin.command:
+    cmd: 'yes | parted /dev/mmcblk0 resizepart 1 100% ---pretend-input-tty'
+
+- name: Resize Filesystem
+  ansible.builtin.command:
+    cmd: 'sudo resize2fs /dev/mmcblk0p1'
+
+# df -hT | grep -e 'mmcblk.*ext4.* /' | cut -d" " -s --fields=3

--- a/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
+++ b/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
@@ -21,12 +21,17 @@
     state: directory
     mode: "a+rwx"
 
+- name: Test if Node has Access to datastorage
+  ansible.builtin.command:
+    cmd: "ping -c 1 -W 5 {{ testbed_observer_nfs_server | split(':')[0] }}"
+  failed_when: false
+  register: nfs_available
+
+
 - name: Mount root of datastorage (temporary)
   ansible.builtin.command:
     cmd: "mount -t nfs4 {{ testbed_observer_nfs_server }} /tmp/shp_drive/"
-  register: mounted_tmp
-  failed_when: false
-  timeout: 20
+  when: nfs_available is not failed
 
 - name: Create directories (future mount-points of nfs-share)
   ansible.builtin.file:
@@ -37,7 +42,7 @@
     - "/tmp/shp_drive/experiments/"
     - "/tmp/shp_drive/experiments/{{ testbed_observer_hostname }}"
     - "/tmp/shp_drive/content/"
-  when: mounted_tmp is not failed
+  when: nfs_available is not failed
 
 # Cleanup
 

--- a/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
+++ b/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
@@ -21,12 +21,12 @@
     state: directory
     mode: "a+rwx"
 
+# create future mountpoints on share
 - name: Test if Node has Access to datastorage
   ansible.builtin.command:
-    cmd: "ping -c 1 -W 5 {{ testbed_observer_nfs_server | split(':')[0] }}"
+    cmd: "ping -c 1 -W 5 {{ testbed_observer_nfs_server | split(':') | first }}"
   failed_when: false
   register: nfs_available
-
 
 - name: Mount root of datastorage (temporary)
   ansible.builtin.command:

--- a/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
+++ b/deploy/roles/testbed_observer/tasks/integrate_nes_datastorage.yml
@@ -31,7 +31,7 @@
 - name: Mount root of datastorage (temporary)
   ansible.builtin.command:
     cmd: "mount -t nfs4 {{ testbed_observer_nfs_server }} /tmp/shp_drive/"
-  when: nfs_available is not failed
+  when: nfs_available.rc == 0
 
 - name: Create directories (future mount-points of nfs-share)
   ansible.builtin.file:
@@ -42,7 +42,7 @@
     - "/tmp/shp_drive/experiments/"
     - "/tmp/shp_drive/experiments/{{ testbed_observer_hostname }}"
     - "/tmp/shp_drive/content/"
-  when: nfs_available is not failed
+  when: nfs_available.rc == 0
 
 # Cleanup
 

--- a/deploy/roles/testbed_observer/tasks/main.yml
+++ b/deploy/roles/testbed_observer/tasks/main.yml
@@ -12,6 +12,10 @@
   ansible.builtin.include_tasks:
     file: broadcast_mac.yml
 
+- name: Grow Root-Filesystem (for fresh images)
+  ansible.builtin.include_tasks:
+    file: grow_root_partition.yml
+
 - name: Extended watchdog reboots unreachable observers in testbed
   ansible.builtin.include_tasks:
     file: activate_internet_watchdog.yml

--- a/deploy/roles/testbed_observer/tasks/main.yml
+++ b/deploy/roles/testbed_observer/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Grow Root-Filesystem (for fresh images)
   ansible.builtin.include_tasks:
     file: grow_root_partition.yml
+  when: false
 
 - name: Extended watchdog reboots unreachable observers in testbed
   ansible.builtin.include_tasks:

--- a/software/python-package/shepherd_sheep/sys_ptp_status.py
+++ b/software/python-package/shepherd_sheep/sys_ptp_status.py
@@ -102,7 +102,7 @@ class PTPStatus:
                 log.info(
                     "[%s] goal reached in %.0f s!",
                     type(self).__name__,
-                    time_now - time_start,
+                    (time_now - time_start).total_seconds(),
                 )
                 return True
 

--- a/software/shepherd-herd/shepherd_herd/herd.py
+++ b/software/shepherd-herd/shepherd_herd/herd.py
@@ -211,6 +211,8 @@ class Herd:
         """
         threads = {}
         for cnx in self.group_all:
+            if cnx.is_connected:  # fast-path to keep thread-count low
+                continue
             hname = self.hostnames[cnx.host]
             threads[hname] = threading.Thread(target=self._thread_open, args=[cnx])
             threads[hname].start()


### PR DESCRIPTION
Ansible
- observer-role
  - allow adding datastorage without connection
  - grow root-partition/FS (disabled for now)
- improve sshd-stability
- ptp-host-role
  - revert to use included PTP
  - try normal hw-filtering
  - disable PTP-compiling and reload systemd after setup

Misc
- sheep - fix exception during end of resync
- herd - make .open() less demanding